### PR TITLE
Change links to secondary and services to minor

### DIFF
--- a/grpk/src/main/java/lt/biip/basemap/layers/Transportation.java
+++ b/grpk/src/main/java/lt/biip/basemap/layers/Transportation.java
@@ -39,9 +39,9 @@ public class Transportation implements ForwardingProfile.FeaturePostProcessor, F
                 } else if (tipas == 6) {
                     // Gerosios vilties st. and other similar streets belong to tipas 6
                     // For now just assign service, because residential filters it out in some styles completely
-                    addTransportationFeature(FieldValue.CLASS_SERVICE, null, 12, sf, features);
-                } else if (tipas == 7 && paskirtis.equals("JUNG")) {
-                    addTransportationFeature(FieldValue.CLASS_LINK, null, 13, sf, features);
+                    addTransportationFeature(FieldValue.CLASS_MINOR, null, 12, sf, features);
+                } else if (tipas == 7 && (paskirtis.equals("JUNG") || paskirtis.equals("LEGR"))) {
+                    addTransportationFeature(FieldValue.CLASS_SECONDARY, null, 12, sf, features);
                 } else if (tipas == 7 || tipas == 9) {
                     addTransportationFeature(FieldValue.CLASS_SERVICE, null, 13, sf, features);
                 } else if (tipas == 8 && danga.equals("Ž")) {
@@ -86,7 +86,7 @@ public class Transportation implements ForwardingProfile.FeaturePostProcessor, F
 
         var brunnel = switch (level) {
             case 1, 2, 3 -> "bridge";
-            case -1 -> "tunnell";
+            case -1 -> "tunnel";
             default -> null;
         };
 
@@ -155,6 +155,7 @@ public class Transportation implements ForwardingProfile.FeaturePostProcessor, F
         static final String CLASS_TERTIARY = "tertiary";
         static final String CLASS_RESIDENTIAL = "residential";
         static final String CLASS_LINK = "link";
+        static final String CLASS_MINOR = "minor";
         static final String CLASS_SERVICE = "service";
         static final String CLASS_PATH = "path";
         static final String CLASS_FERRY = "ferry";


### PR DESCRIPTION
Fix link class issue and now links and acceleration, deceleration lanes are interpreted as secondary class (similar to openmaptiles):
![image](https://github.com/AplinkosMinisterija/biip-vector-basemap/assets/1758436/b927601b-5c48-47a5-89f8-1211394e651f)
Also changed services class used in the cities to minor (similar to openmaptiles).
