### PR TITLE
CDN cache-busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ Once deployed, the following styles will be available:
 - **Positron Style**: `https://basemap.yourdomain.com/style/positron` - Gray basemap style
 - **OpenMapTiles Style**: `https://basemap.yourdomain.com/style/openmaptiles` - Standard OpenMapTiles style
 
+> [!TIP]
+> **CDN & Cache Busting**
+>
+> Vector tile URLs automatically include a version parameter
+> (e.g., `https://basemap.yourdomain.com/{z}/{x}/{y}.pbf?version=1.2.0`).
+> We recommend configuring your CDN to serve these tiles
+> with caching enabled, for example: `Cache-Control: public, max-age=31536000, immutable`. This allows for aggressive
+> caching while ensuring a clean cache-bust whenever the Docker image and its tileset are updated.
+
 #### Usage Example
 
 ```js

--- a/vector/docker/Dockerfile
+++ b/vector/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY vector ./vector
 
 RUN ./gradlew run
 
-FROM ghcr.io/maplibre/martin:1.3.1
+FROM ghcr.io/maplibre/martin:1.4.0
 
 # Let's use non root user
 ARG USER=basemap

--- a/vector/docker/martin/config.yaml
+++ b/vector/docker/martin/config.yaml
@@ -2,6 +2,8 @@ preferred_encoding: gzip
 
 base_path: /
 
+tilejson_url_version_param: version
+
 pmtiles:
   sources:
     vector: /opt/vector/pmtiles/lithuania.pmtiles

--- a/vector/preview/martin.Dockerfile
+++ b/vector/preview/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:1.3.0
+FROM ghcr.io/maplibre/martin:1.4.0
 
 ENV HOST="http://127.0.0.1:3000"
 


### PR DESCRIPTION
Embeds the MBTiles/PMTiles version metadata directly into tile URLs as a query parameter. This allows for long-term immutable caching at the CDN/browser level while ensuring clients automatically fetch new tiles when a tileset is updated.